### PR TITLE
Redis auto-configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
+    compile("redis.clients:jedis:2.1.0")
+    compile("org.springframework.data:spring-data-redis:1.6.1.RELEASE")
     testCompile("junit:junit")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 buildscript {
+    ext {
+        springBootVersion = '1.3.0.RELEASE'
+    }
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.0.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     }
 }
 
@@ -26,8 +29,7 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
-    compile("redis.clients:jedis:2.1.0")
-    compile("org.springframework.data:spring-data-redis:1.6.1.RELEASE")
+    compile('org.springframework.boot:spring-boot-starter-redis')
     testCompile("junit:junit")
 }
 

--- a/src/main/java/cfenv/Analytics.java
+++ b/src/main/java/cfenv/Analytics.java
@@ -2,7 +2,9 @@ package cfenv;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.support.atomic.RedisAtomicLong;
+import org.springframework.stereotype.Component;
 
+@Component
 public class Analytics {
 	private final StringRedisTemplate template;
 

--- a/src/main/java/cfenv/Analytics.java
+++ b/src/main/java/cfenv/Analytics.java
@@ -1,0 +1,20 @@
+package cfenv;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.support.atomic.RedisAtomicLong;
+
+public class Analytics {
+	private final StringRedisTemplate template;
+
+	private final RedisAtomicLong visits;
+
+	public Analytics(StringRedisTemplate template) {
+		this.template = template;
+
+		visits = new RedisAtomicLong("visits", template.getConnectionFactory());
+	}
+
+	public String getVisits() {
+		return String.valueOf(visits.incrementAndGet());
+	}
+}

--- a/src/main/java/cfenv/Application.java
+++ b/src/main/java/cfenv/Application.java
@@ -2,11 +2,19 @@ package cfenv;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @SpringBootApplication
 public class Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    Analytics analytics(RedisTemplate redisTemplate) {
+        return new Analytics(new StringRedisTemplate(redisTemplate.getConnectionFactory()));
     }
 }

--- a/src/main/java/cfenv/CFEnv.java
+++ b/src/main/java/cfenv/CFEnv.java
@@ -2,12 +2,18 @@ package cfenv;
 
 public class CFEnv {
 	private final String instance;
+	private final String visits;
 
-	public CFEnv(String instance) {
+	public CFEnv(String instance, String visits) {
 		this.instance = instance;
+		this.visits = visits;
 	}
 
 	public String getInstance() {
 		return instance;
+	}
+
+	public String getVisits() {
+		return visits;
 	}
 }

--- a/src/main/java/cfenv/CFEnvController.java
+++ b/src/main/java/cfenv/CFEnvController.java
@@ -3,16 +3,29 @@ package cfenv;
 import java.util.Map;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @RestController
 public class CFEnvController {
+	@Autowired
+	private final Analytics analytics;
+
+	@Autowired
+	public CFEnvController(Analytics analytics) {
+		this.analytics = analytics;
+	}
+
 	@RequestMapping("/")
 	public CFEnv cfenv() {
-		return new CFEnv(getInstanceFromEnv());
+		return new CFEnv(getInstanceFromEnv(), getVisits());
 	}
 
 	private String getInstanceFromEnv() {
 		Map<String, String> env = System.getenv();
 		return env.get("CF_INSTANCE_INDEX");
+	}
+
+	private String getVisits() {
+		return analytics.getVisits();
 	}
 }

--- a/src/main/java/cfenv/CFEnvController.java
+++ b/src/main/java/cfenv/CFEnvController.java
@@ -1,13 +1,14 @@
 package cfenv;
 
-import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
 
 @RestController
 public class CFEnvController {
-	@Autowired
+
 	private final Analytics analytics;
 
 	@Autowired


### PR DESCRIPTION
Added Spring Boot starter for Redis. Removed Spring Data and Redis driver dependencies. Added Spring Boot 1.3.0 as parent.

Moved around the autowiring of the Analytics bean and configured it with the Redis connection factory in the application class.